### PR TITLE
Fixed f-string that triggered F541 flake8 violation code with python 3.8

### DIFF
--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.repo_name.replace("-", "_") }}/util/logging.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.repo_name.replace("-", "_") }}/util/logging.py
@@ -85,7 +85,7 @@ def setup_logging_env(main: Callable) -> Callable:
     def wrapper(*args, **kwargs):
         setup_logging()
         load_dotenv(find_dotenv())
-        logger.info(f"Loaded environment variables")
+        logger.info("Loaded environment variables")
         logger.info(f"Starting {main.__name__}() in {sys.argv[0]}")
         t = TicToc()
         t.tic()


### PR DESCRIPTION
# Context

Fixes a f-string in logging.py to avoid flake8 violation code F541: "f-string without any placeholders". This was triggering CI build fails when using orbyter 3.0 docker images.

# Changes

* Change f-string to standard string on line 88

# Behaves Differently

* CI no longer fails for scaffolded repo when using orbyter 3.0 images.
