### PR TITLE
Headers now match Sphinx style guide

### DIFF
--- a/{{ cookiecutter.repo_name }}/docsrc/index.rst
+++ b/{{ cookiecutter.repo_name }}/docsrc/index.rst
@@ -1,37 +1,43 @@
+###############################
 {{ cookiecutter.project_name }} documentation
-==============================================
+###############################
 
 .. toctree::
    :maxdepth: 2
 
+*******************************
 {{ cookiecutter.repo_name }}.scripts.train
-===================================================
+*******************************
 .. automodule:: {{ cookiecutter.repo_name }}.scripts.train
     :members:
-    
+
+*******************************
 {{ cookiecutter.repo_name }}.scripts.evaluate
-===================================================
+*******************************
 .. automodule:: {{ cookiecutter.repo_name }}.scripts.evaluate
     :members:
 
+*******************************
 {{ cookiecutter.repo_name }}.scripts.predict
-===================================================
+*******************************
 .. automodule:: {{ cookiecutter.repo_name }}.scripts.predict
     :members:
 
+*******************************
 {{ cookiecutter.repo_name }}.util.config
-===================================================
+*******************************
 .. automodule:: {{ cookiecutter.repo_name }}.util.config
     :members:
 
+*******************************
 {{ cookiecutter.repo_name }}.util.logging
-===================================================
+*******************************
 .. automodule:: {{ cookiecutter.repo_name }}.util.logging
     :members:
 
-
+********************************
 Indices and tables
-==================
+********************************
 
 * :ref:`genindex`
 * :ref:`modindex`


### PR DESCRIPTION
# Context

The headers don't match the Sphinx style guide right now (https://documentation-style-guide-sphinx.readthedocs.io/en/latest/style-guide.html). Essentially, it's starting with H3.

# Changes

* Add an H1 at the top with the name of the project (recommended)
* Made the H3s->H2s

# Behaves Differently

* Formatting a bit different

# Untested

* Docs look good with this formatting.

