### PR TITLE
fix(ci): changed github ci workflow to run ci in container defined by project dockerfile

### DIFF
--- a/{{ cookiecutter.repo_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.repo_name }}/.github/workflows/ci.yml
@@ -3,21 +3,23 @@ name: Continuous Integration
 on: [push]
 
 jobs:
-    test:
-      runs-on: ubuntu-latest
-      container:
-        image: docker://{{ cookiecutter.base_docker_image }}
-      steps:
+  test:
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Black
-        run: black --check {{ cookiecutter.repo_name }}
-      - name: Flake8 
-        run: flake8 {{ cookiecutter.repo_name }}
+        uses: ./docker/action
+        with:
+          command: black --check {{ cookiecutter.repo_name }}
+      - name: Flake8
+        uses: ./docker/action
+        with:
+          command: flake8 {{ cookiecutter.repo_name }}
       - name: Unit Tests
-        run: |
-          pip install -r docker/requirements.txt
-          pytest {{ cookiecutter.repo_name }}
+        uses: ./docker/action
+        with:
+          command: pytest {{ cookiecutter.repo_name }}
         env:
-          MLFLOW_TRACKING_URI: /experiments
-          MLFLOW_ARTIFACT_LOCATION: 
+          MLFLOW_TRACKING_URI: {{ cookiecutter.mlflow_uri }}
+          MLFLOW_ARTIFACT_LOCATION: {{ cookiecutter.mlflow_artifact }}

--- a/{{ cookiecutter.repo_name }}/docker/action/README.md
+++ b/{{ cookiecutter.repo_name }}/docker/action/README.md
@@ -5,6 +5,11 @@ the local Dockerfile. Commands are passed to the container via the `command`
 input and received by an entrypoint script `action-exec.sh` that feeds the
 command string to `bash -c`
 
+## Documentation
+The documentation for how this action works can be found here:
+* [Creating a Docker container action](https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-docker-container-action)
+* [Dockerfile support for GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/dockerfile-support-for-github-actions)
+
 ## Inputs
 
 ### `command`

--- a/{{ cookiecutter.repo_name }}/docker/action/README.md
+++ b/{{ cookiecutter.repo_name }}/docker/action/README.md
@@ -1,0 +1,25 @@
+# Dockerfile CI action
+
+This action executes arbitrary commands within a Docker container defined by
+the local Dockerfile. Commands are passed to the container via the `command`
+input and received by an entrypoint script `action-exec.sh` that feeds the
+command string to `bash -c`
+
+## Inputs
+
+### `command`
+
+**Required** - String of commands and arguments to pass to `bash -c` command.
+Default command is `pytest {{ cookiecutter.repo_name }}`.
+
+## Example usage
+
+```yaml
+steps:
+  - name: Checkout
+    uses: actions/checkout@v1
+  - name: CI
+    uses: ./docker/action
+    with:
+      command: pytest {{ cookiecutter.repo_name }}
+```

--- a/{{ cookiecutter.repo_name }}/docker/action/action-exec.sh
+++ b/{{ cookiecutter.repo_name }}/docker/action/action-exec.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# This script is used as the entry-point for the GitHub action defined by
+# action.yml. This script executes the commands and arguments passed to the
+# action via the `command` key.
+
+bash -c "$*"

--- a/{{ cookiecutter.repo_name }}/docker/action/action.yml
+++ b/{{ cookiecutter.repo_name }}/docker/action/action.yml
@@ -1,4 +1,4 @@
-# This defines a GitHub aaction that executes arbitrary commands within a Docker
+# This defines a GitHub action that executes arbitrary commands within a Docker
 # container defined by the local Dockerfile. Commands are passed to the
 # container via the `command` key and received by an entrypoint script that
 # feeds the command string to `bash -c`. See README for details.

--- a/{{ cookiecutter.repo_name }}/docker/action/action.yml
+++ b/{{ cookiecutter.repo_name }}/docker/action/action.yml
@@ -1,0 +1,18 @@
+# This defines a GitHub aaction that executes arbitrary commands within a Docker
+# container defined by the local Dockerfile. Commands are passed to the
+# container via the `command` key and received by an entrypoint script that
+# feeds the command string to `bash -c`. See README for details.
+
+name: "Dockerfile CI"
+description: "Execute commands inside container defined by local Dockerfile"
+inputs:
+  command: # Command string to docker exec
+    description: "Command string to docker exec"
+    required: true
+    default: "pytest {{ cookiecutter.repo_name }}"
+runs:
+  using: "docker"
+  image: "../Dockerfile"
+  entrypoint: "./docker/action/action-exec.sh"
+  args:
+    - {{ "${{ inputs.command }}" }}


### PR DESCRIPTION
# Context

Previously, the default CI workflow tries running the tests on the base orbyter image, and assumes that there are no dependencies installed in the project Dockerfile. This forces everyone to update the CI workflow yaml file every time the Dockerfile is updated in order to have a consistent CI setup.

This fixes the problem by updating the github CI workflow to use a github action defined in the `docker/action` directory that uses the project Dockerfile to build the container for running CI.

# Changes

* CI workflow invokes the github action defined in the `docker/action` directory
* Github action is defined in `docker/action/action.yml` file and the action documentation is in `docker/action/README.md`.
* Added bash script `docker/action/action-exec.sh` that acts as an entrypoint for container.

# Behaves Differently

* CI will always run in the container defined by the project Dockerfile, and we won't have to update the CI workflow if the Dockerfile changes.
