### PR TITLE
Bumping orbyter ml-dev image to 3.0

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,7 @@
     "open_source_license": "Not open source",
     "author_name": "",
     "description": "My Project Description",
-    "base_docker_image": "manifoldai/orbyter-ml-dev:2.1",
+    "base_docker_image": "manifoldai/orbyter-ml-dev:3.0",
     "mlflow_uri": "/mnt/experiments",
     "mlflow_artifact": ""
 }


### PR DESCRIPTION
# Context

The title is the entire PR. Very simple. 

# Changes

* Changed cookiecutter.json file to have 3.0 as default image. 

