### PR TITLE
Move to Orbyter 3.1 image

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,7 @@
     "open_source_license": "Not open source",
     "author_name": "",
     "description": "My Project Description",
-    "base_docker_image": "manifoldai/orbyter-ml-dev:3.0",
+    "base_docker_image": "manifoldai/orbyter-ml-dev:3.1",
     "mlflow_uri": "/mnt/experiments",
     "mlflow_artifact": ""
 }

--- a/{{ cookiecutter.repo_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.repo_name }}/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on: [push]
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Context

Moving to new 3.1 Orbyter ml-dev image as the default. 

# Changes

* Change default image
* Changed name of action (from test -> ci)

Closes #31 
