### PR TITLE
Spin up containers before running tests/lint

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -43,6 +43,8 @@ dev-start: ## Primary make command for devs, spins up containers
 dev-stop: ## Spin down active containers
 	docker-compose -f docker/docker-compose.yml --project-name {{ cookiecutter.repo_name }} down
 
+dev-rebuild: ## Rebuild images for dev containers (useful when Dockerfile/requirements are updated)
+	docker-compose -f docker/docker-compose.yml --project-name $(PROJECT) up -d --build
 
 docs: ## Build docs using Sphinx and copy to docs folder (this makes it easy to publish to gh-pages)
 	docker exec -e GRANT_SUDO=yes $(CONTAINER_NAME) bash -c "cd docsrc; make html"

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help, ci-black, ci-flake8, ci-test, isort, black, docs
+.PHONY: help, ci-black, ci-flake8, ci-test, isort, black, docs, dev-start, dev-stop
 
 PROJECT={{ cookiecutter.repo_name }}
 CONTAINER_NAME="{{ cookiecutter.repo_name }}_bash_${USER}"  ## Ensure this is the same name as in docker-compose.yml file
@@ -13,13 +13,13 @@ git-tag:  ## Tag in git, then push tag up to origin
 	git tag $(TAG)
 	git push origin $(TAG)
 
-ci-black: ## Test lint compliance using black. Config in pyproject.toml file
+ci-black: dev-start ## Test lint compliance using black. Config in pyproject.toml file
 	docker exec $(CONTAINER_NAME) black --check $(PROJ_DIR)
 
-ci-flake8: ## Test lint compliance using flake8. Config in tox.ini file
+ci-flake8: dev-start ## Test lint compliance using flake8. Config in tox.ini file
 	docker exec $(CONTAINER_NAME) flake8 $(PROJ_DIR)
 
-ci-test:  ## Runs unit tests using pytest
+ci-test: dev-start ## Runs unit tests using pytest
 	docker exec $(CONTAINER_NAME) pytest $(PROJ_DIR)
 
 ci-test-interactive:  ## Runs unit tests using pytest, and gives you an interactive IPDB session at the first failure
@@ -28,18 +28,17 @@ ci-test-interactive:  ## Runs unit tests using pytest, and gives you an interact
 ci: ci-black ci-flake8 ci-test ## Check black, flake8, and run unit tests
 	@echo "CI sucessful"
 
-isort: ## Runs isort to sorts imports
+isort: dev-start  ## Runs isort to sorts imports
 	docker exec $(CONTAINER_NAME) isort -rc $(PROJ_DIR)
 
-black: ## Runs black auto-linter
+black: dev-start ## Runs black auto-linter
 	docker exec $(CONTAINER_NAME) black $(PROJ_DIR)
 
 lint: isort black ## Lints repo; runs black and isort on all files
 	@echo "Linting complete"
 
 dev-start: ## Primary make command for devs, spins up containers
-	@echo "Building new images from compose"
-	docker-compose -f docker/docker-compose.yml --project-name $(PROJECT) up -d --build
+	docker-compose -f docker/docker-compose.yml --project-name $(PROJECT) up -d --no-recreate
 
 dev-stop: ## Spin down active containers
 	docker-compose -f docker/docker-compose.yml --project-name {{ cookiecutter.repo_name }} down


### PR DESCRIPTION
# Context

Test/lint make commands fail out of the box because they require `dev-start`. However, this is not listed as a requirement. I believe this was removed because someone was annoyed the about the docker images building every time. So, we have three options:

1. Keep as is. CON: inproper use of a Makefile. Requirements should be listed for all commands
2. Add `dev-start` requirement and always rebuild. CON: takes a bit more time as images need to build
3. Add `dev-start` and don't rebuild images in container is running.

This PR implements 3.

# Changes

* Add `dev-start` requiremnt
* Don't rebuild images in containers are running

# Behaves Differently

## Before

### Initial run

<img width="943" alt="image" src="https://user-images.githubusercontent.com/12516153/103377362-1140b280-4a94-11eb-88c0-4ac78dcbb9b9.png">

## After

### Initial run

<img width="947" alt="image" src="https://user-images.githubusercontent.com/12516153/103377384-20276500-4a94-11eb-9c1e-174907612916.png">

### Subsequent run

<img width="940" alt="image" src="https://user-images.githubusercontent.com/12516153/103377475-5a910200-4a94-11eb-842f-119afe76d175.png">


### How it would behave with `--build`

<img width="607" alt="image" src="https://user-images.githubusercontent.com/12516153/103377514-772d3a00-4a94-11eb-851a-4550fe62b549.png">


