### PR TITLE
rename lint -> format

### DIFF
--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -37,8 +37,10 @@ isort: dev-start  ## Runs isort to sorts imports
 black: dev-start ## Runs black auto-linter
 	docker exec $(CONTAINER_NAME) black $(PROJ_DIR)
 
-lint: isort black ## Lints repo; runs black and isort on all files
-	@echo "Linting complete"
+lint: format ## Deprecated. Here to support old workflow
+
+format: isort black ## Formats repo; runs black and isort on all files
+	@echo "Formatting complete"
 
 dev-start: ## Primary make command for devs, spins up containers
 	docker-compose -f docker/docker-compose.yml --project-name $(PROJECT) up -d --no-recreate

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -79,7 +79,7 @@ make help
 The `make` commands supported out of the box are:
 
 ```
-black                          Runs black auto-linter
+black                          Runs black auto-formatter
 ci-black                       Test lint compliance using black. Config in pyproject.toml file
 ci-test                        Runs unit tests using pytest
 ci                             Check black, flake8, and run unit tests
@@ -88,7 +88,7 @@ dev-stop                       Spin down active containers
 docs                           Build docs using Sphinx and copy to docs folder (this makes it easy to publish to gh-pages)
 git-tag                        Tag in git, then push tag up to origin
 isort                          Runs isort to sorts imports
-lint                           Lints repo; runs black and isort on all files
+format                           Formats repo; runs black and isort on all files
 ```
 
 ## Using the Containers


### PR DESCRIPTION
# Context

Linters don't change code, they only check that it obeys rules https://en.wikipedia.org/wiki/Lint_(software)

`black` and `isort` are code formatters (though black can also be used to lint, as it is in `ci-black`

# Changes

* Add a new command `format` which is an alias of deprecated command `lint`