### PR TITLE
fix(build): Fix default build and add github CI for cookiecutter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Continuous Integration
+
+on: [push]
+
+jobs:
+  test:
+    name: Test by running cookiecutter
+    runs-on: ubuntu-latest
+    env:
+      TEST_PROJECT: foundation
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: 'orbyter-cookiecutter'
+      - name: Install cookiecutter
+        run: pip install cookiecutter
+      - name: Cut a cookie (repo)
+        run: "python -m cookiecutter --no-input orbyter-cookiecutter project_name=$TEST_PROJECT repo_name=$TEST_PROJECT"
+      - name: Build project containers (make dev-start)
+        working-directory: ${{env.TEST_PROJECT}}
+        run: make dev-start
+      - name: Run initial project tests (make ci)
+        working-directory: ${{env.TEST_PROJECT}}
+        run: make ci

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Helping ML teams easily move to a Docker-first development workflow to iterate and deliver projects faster and more reliably.**
 
+![Continuous integration](https://github.com/manifoldai/orbyter-cookiecutter/actions/workflows/ci.yml/badge.svg)
+
 *New to Docker? Check out this writeup on containers vs virtual machines and how Docker fits in:*
 
 *https://medium.freecodecamp.org/a-beginner-friendly-introduction-to-containers-vms-and-docker-79a9e3e119b*

--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.package_name }}/scripts/train_test.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.package_name }}/scripts/train_test.py
@@ -3,18 +3,14 @@ import pathlib
 
 from click.testing import CliRunner
 
-from {{cookiecutter.package_name}}.scripts.train import main, _main
+from {{ cookiecutter.package_name }}.scripts.train import main, _main
 
 _HERE = pathlib.Path(__file__).resolve().parent
 
 
 @pytest.mark.parametrize("config_file", [("configs/config.yml")])
 def test_click_main(config_file):
-    """
-    This tests the _main() click runner AND ensures the main() function within it works
-    correctly when called by click
-    ```
-    """
+    """Tests both _main() click runner and its call to main()"""
     runner = CliRunner()
     try:
         result = runner.invoke(_main, [config_file])
@@ -27,8 +23,8 @@ def test_click_main(config_file):
 
 
 def test_main():
-    """ This tests the function main() independently from the _main() click command
-    
+    """Tests the function main() independently from main() click command
+
     This pattern aids in writing tests, as the function with the click decorators can be
     separately tested from the script functionality itself. In addition, the main()
     function can now be imported and used in other python modules


### PR DESCRIPTION
# Context

The default tests were failing, and we had no CI to block us from merging buggy commits to master. Now, all* of that is solved!

# Changes

* Minor black fixes
* Add Github CI: runs `cookiecutter`, and then within the new project, `make dev-start` and `make ci`.

# Behaves Differently

* Due to all the container overhead in the above steps, CI takes a few minutes to run for every commit/PR.

# Untested

* Other commands (`make X`), etc.: these should be fairly easy to add by pattern-matching in `ci.yml`.

Closes #56. 

\* This won't catch every bug, but it should get the most egregious ones that break the cookiecutter, the container build, or the default tests.