### PR TITLE
fix(misc): misc fixes to Makefile, and remove bash container

### DIFF
--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -1,9 +1,13 @@
 .PHONY: help, ci-black, ci-flake8, ci-test, isort, black, docs, dev-start, dev-stop
 
+## Ensure this is the same name as in docker-compose.yml file
+CONTAINER_NAME="{{ cookiecutter.package_name }}_jupyter_${USER}"
+
 PROJECT={{ cookiecutter.package_name }}
-CONTAINER_NAME="{{ cookiecutter.package_name }}_bash_${USER}"  ## Ensure this is the same name as in docker-compose.yml file
+
 PROJ_DIR="/mnt/{{ cookiecutter.package_name }}"
 VERSION_FILE:=VERSION
+COMPOSE_FILE=docker/docker-compose.yml
 TAG:=$(shell cat ${VERSION_FILE})
 
 help:
@@ -13,54 +17,71 @@ git-tag:  ## Tag in git, then push tag up to origin
 	git tag $(TAG)
 	git push origin $(TAG)
 
-ci-black: dev-start ## Test lint compliance using black. Config in pyproject.toml file
+## Test lint compliance using black. Config in pyproject.toml file
+ci-black: dev-start
 	docker exec -t $(CONTAINER_NAME) black --check $(PROJ_DIR)
 
-ci-flake8: dev-start ## Test lint compliance using flake8. Config in tox.ini file
+## Test lint compliance using flake8. Config in tox.ini file
+ci-flake8: dev-start
 	docker exec -t $(CONTAINER_NAME) flake8 $(PROJ_DIR)
 
-ci-test: dev-start ## Runs unit tests using pytest
+## Runs unit tests using pytest
+ci-test: dev-start
 	docker exec -t $(CONTAINER_NAME) pytest $(PROJ_DIR)
 
-ci-mypy: dev-start ## Runs mypy type checker
-	docker exec -t $(CONTAINER_NAME) mypy --ignore-missing-imports $(PROJ_DIR)
-
-ci-test-interactive:  ## Runs unit tests using pytest, and gives you an interactive IPDB session at the first failure
+## Runs unit tests, with an interactive IPDB session at the first failure
+ci-test-interactive: dev-start
 	docker exec -it $(CONTAINER_NAME) pytest $(PROJ_DIR)  -x --pdb --pdbcls=IPython.terminal.debugger:Pdb
 
-ci: ci-black ci-flake8 ci-test ci-mypy ## Check black, flake8, and run unit tests
+## Runs mypy type checker
+ci-mypy: dev-start
+	docker exec -t $(CONTAINER_NAME) mypy --ignore-missing-imports --show-error-codes $(PROJ_DIR)
+
+## Check black, flake8, and run unit tests
+ci: ci-black ci-flake8 ci-test ci-mypy
 	@echo "CI successful"
 
-isort: dev-start  ## Runs isort to sorts imports
-	docker exec -t $(CONTAINER_NAME) isort -rc $(PROJ_DIR)
+## Runs isort to sorts imports
+isort: dev-start
+	docker exec -t $(CONTAINER_NAME) isort -rc $(PROJ_DIR)  --profile black
 
-black: dev-start ## Runs black auto-linter
+## Runs black auto-linter
+black: dev-start
 	docker exec -t $(CONTAINER_NAME) black $(PROJ_DIR)
 
-lint: format ## Deprecated. Here to support old workflow
-
-format: isort black ## Formats repo; runs black and isort on all files
+## Formats repo; runs black and isort on all files
+format: isort black
 	@echo "Formatting complete"
 
-dev-start: ## Primary make command for devs, spins up containers
-	docker-compose -f docker/docker-compose.yml --project-name $(PROJECT) up -d --no-recreate
+## Deprecated. Here to support old workflow
+lint: format
 
-dev-stop: ## Spin down active containers
-	docker-compose -f docker/docker-compose.yml --project-name $(PROJECT) down
+## Primary make command for devs, spins up containers
+dev-start:
+	docker-compose -f $(COMPOSE_FILE) --project-name $(PROJECT) up -d --no-recreate
 
-dev-rebuild: ## Rebuild images for dev containers (useful when Dockerfile/requirements are updated)
-	docker-compose -f docker/docker-compose.yml --project-name $(PROJECT) up -d --build
+## Spin down active containers
+dev-stop:
+	docker-compose -f $(COMPOSE_FILE) --project-name $(PROJECT) down
 
-bash: dev-start ## Exec into docker bash terminal
+## Rebuild images for dev containers (useful when Dockerfile/requirements are updated)
+dev-rebuild:
+	docker-compose -f $(COMPOSE_FILE) --project-name $(PROJECT) up -d --build
+
+## Exec into docker bash terminal
+bash: dev-start
 	docker exec -it $(CONTAINER_NAME) bash
 
-docs: ## Build docs using Sphinx and copy to docs folder (this makes it easy to publish to gh-pages)
+## Build docs using Sphinx and copy to docs folder (this makes it easy to publish to gh-pages)
+docs:
 	docker exec -e GRANT_SUDO=yes $(CONTAINER_NAME) bash -c "cd docsrc; make html"
 	@cp -a docsrc/_build/html/. docs
 
-ipython: ## Provides an interactive ipython prompt
+## Provides an interactive ipython prompt
+ipython:
 	docker exec -it $(CONTAINER_NAME) ipython
 
-clean: ## Clean out temp/compiled python files
+## Clean out temp/compiled python files
+clean:
 	find . -name __pycache__ -delete
 	find . -name "*.pyc" -delete

--- a/{{ cookiecutter.project_name }}/docker/docker-compose.yml
+++ b/{{ cookiecutter.project_name }}/docker/docker-compose.yml
@@ -27,15 +27,3 @@ services:
     tty: true
     env_file:
       - ../.env
-
-  bash:
-    build:
-      context: .
-    volumes:
-      - ../:/mnt
-    entrypoint: "/bin/bash"
-    stdin_open: true
-    container_name: "{{ cookiecutter.package_name }}_bash_${USER}"
-    tty: true
-    env_file:
-      - ../.env


### PR DESCRIPTION
# Context

Address minor issues and usability improvements to Makefile.

I'm planning to cut a new release (2.1.0) after this PR: if you think there are other things that need to be addressed before that, please let me know.

# Changes

* Remove bash container (all CLI entrypoints are run in the jupyter container)
* Improve Makefile readability
* docker-compose file is a Makefile argument so that it's easier to run with different compose files (e.g., a cloud setup with an MLFlow server doesn't need an MLFlow container)
* Small Makefile improvements
  * mypy shows error codes (h/t @joegoldbeck)
  * isort is now compatible w/black (h/t @resdntalien)

# Behaves Differently

* No more bash container

# Untested

* N/A: No new tests, but no new testable features

Closes #52.
Closes #53.
Closes #57.