### PR TITLE
fix(validation): make validation hook python2 compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,11 @@ on: [push]
 
 jobs:
   test:
-    name: Test by running cookiecutter
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['2.x', '3.x']
+    name: Test by running cookiecutter with Python ${{ matrix.python-version }}
     env:
       TEST_PROJECT: foundation
     steps:
@@ -13,6 +16,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: 'orbyter-cookiecutter'
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
       - name: Install cookiecutter
         run: pip install cookiecutter
       - name: Cut a cookie (repo)

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,10 +1,16 @@
-"""Python module name validation."""
+"""Python module name validation.
+
+Compatible with python 2 and python 3, to ensure cookiecutter support
+across various platforms
+"""
 import logging
 import sys
 import re
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
+
+REF_URL = "https://www.python.org/dev/peps/pep-0008/#package-and-module-names"
 
 
 def validate_python_package_name():
@@ -13,11 +19,8 @@ def validate_python_package_name():
     # The following regex will only match valid Python module names
     if not re.match(r"^[a-z][_a-z0-9]+$", package_name):
         # Error out if you have an invalid module name
-        logger.error(
-            f"{package_name} is not a valid Python module name!\n See "
-            "https://www.python.org/dev/peps/pep-0008/#package-and-module-names "
-            "for naming standards.\n"
-        )
+        err = "{} is not a valid Python module name!\n See {} for naming standards."
+        logger.error(err.format(package_name, REF_URL))
         sys.exit(1)
 
 


### PR DESCRIPTION
# Context

When testing locally, I kept running into issues because the version of cookiecutter that I installed through homebrew somehow connected itself to the system python (i.e., `/usr/bin/python`, installed by Mac OS X), which is python 2. This broke the format strings in the pre-generation validation hook.

To minimize user error like mine, this PR keeps the hook compatible with both python2 and python3.

# Changes

* Validation hook no longer uses Python 3 string formatting syntactic sugar `f"{package_name}"`

# Behaves Differently

* N/A

# Untested

* N/A: GH actions will test running cookiecutter with python2 and python3.