### PR TITLE
fix: make docker compose more robust to env vars

### DIFF
--- a/{{ cookiecutter.project_name }}/docker/docker-compose.yml
+++ b/{{ cookiecutter.project_name }}/docker/docker-compose.yml
@@ -21,9 +21,12 @@ services:
       - "127.0.0.1::5000"
     volumes:
       - ../:/mnt
-    entrypoint: bash -c "mlflow server -h 0.0.0.0 --backend-store-uri ${MLFLOW_TRACKING_URI} --default-artifact-root ${MLFLOW_ARTIFACT_LOCATION:-'None'} -p 5000 && /bin/bash"
+    entrypoint: bash -c "mlflow server -h 0.0.0.0 --backend-store-uri $${MLFLOW_TRACKING_URI} --default-artifact-root $${MLFLOW_ARTIFACT_LOCATION:-'None'} -p 5000 && /bin/bash"
     stdin_open: true
     container_name: "{{ cookiecutter.package_name }}_mlflow_${USER}"
     tty: true
+    environment: # takes precedent over env file
+      - MLFLOW_TRACKING_URI
+      - MLFLOW_ARTIFACT_LOCATION
     env_file:
       - ../.env


### PR DESCRIPTION
# Context

I was running into issues running `make dev-start` on a clean cookiecut of the repo: see issue #71. This PR fixes this issue as well as adds additional robustness to the mlflow container

# Changes

* Escape character in docker compose command: (see https://github.com/docker/compose/issues/4189)
* Allow user to `export` MLflow env vars if they don't like `.env` files

# Behaves Differently

* Should fix #71 

Closes #71 . 
