### PR TITLE
fix: remove env vars. empties overwrite .env file

### DIFF
--- a/{{ cookiecutter.project_name }}/docker/docker-compose.yml
+++ b/{{ cookiecutter.project_name }}/docker/docker-compose.yml
@@ -25,8 +25,5 @@ services:
     stdin_open: true
     container_name: "{{ cookiecutter.package_name }}_mlflow_${USER}"
     tty: true
-    environment: # takes precedent over env file
-      - MLFLOW_TRACKING_URI
-      - MLFLOW_ARTIFACT_LOCATION
     env_file:
       - ../.env


### PR DESCRIPTION
# Context

I broke the mlflow container in my last PR. If you pass env vars through `environment:` in the docker compose and they aren't set, docker thinks they are empty even if they are in the `.env`

# Changes

* remove env vars from mlflow container :(


# Behaves Differently

* mlflow container spins up

I cookiecut this branch and ran `make dev-start`

<img width="724" alt="image" src="https://user-images.githubusercontent.com/12516153/114945428-8a2b0680-9e06-11eb-857d-895f3a752520.png">
