### PR TITLE
feat: add check for 2 spun up docker containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
         run: make ci
       - name: Verify docker
         working-directory: ${{env.TEST_PROJECT}}
-        run: bash -c '[ `docker ps | wc -l` -eq 4 ] && echo "Success, 2 containers running" || exit 1'
+        run: bash -c '[ `docker ps | wc -l` -eq 3 ] && echo "Success, 2 containers running" || exit 1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
       - name: Run initial project tests (make ci)
         working-directory: ${{env.TEST_PROJECT}}
         run: make ci
+      - name: Verify docker
+        working-directory: ${{env.TEST_PROJECT}}
+        run: [ `docker ps | wc -l` -eq 3 ] && echo "Success, 2 containers running" || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
         run: make ci
       - name: Verify docker
         working-directory: ${{env.TEST_PROJECT}}
-        run: [ `docker ps | wc -l` -eq 3 ] && echo "Success, 2 containers running" || exit 1
+        run: bash -c '[ `docker ps | wc -l` -eq 4 ] && echo "Success, 2 containers running" || exit 1'


### PR DESCRIPTION
# Context

We never verify that we aren't making changes that effect the docker containers spinning up. Here, we add a test to check two containers are being spun up

# Changes

* Add a verify docker container count to CI


# Behaves Differently
* Will fail if two containers don't spin up

### Example fail checking for 3 containers

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/12516153/114949795-fc9fe480-9e0e-11eb-9aee-176eb94e3d01.png">


### Example pass checking for 2 containers

<img width="1429" alt="image" src="https://user-images.githubusercontent.com/12516153/114949822-117c7800-9e0f-11eb-9d0f-1985c4cbdb78.png">


Closes #59  
