### PR TITLE
doc: clarify where documentation is

### DIFF
--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -85,6 +85,7 @@ dvc-init: dev-start ## initialize DVC
 docs: dev-start ## Build docs using Sphinx and copy to docs folder
 	docker exec -e GRANT_SUDO=yes $(CONTAINER_NAME) bash -c "cd docsrc; make html"
 	@cp -a docsrc/_build/html/. docs
+	@echo "Documentation copied to ./docs. Open ./docs/index.html and take a look."
 
 
 ipython: dev-start ## Provides an interactive ipython prompt


### PR DESCRIPTION
# Context

The `make docs` messaged are confusing. They make it difficult to find the docs. This PR clarifies that.

# Changes

* Echo helpful message

# Behaves differently
<img width="523" alt="image" src="https://user-images.githubusercontent.com/12516153/116265783-40a8b880-a730-11eb-8820-5a4cc71c543c.png">
