### PR TITLE
feat: bump docker image version to 3.5

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,7 @@
   "open_source_license": "Not open source",
   "author_name": "",
   "description": "My Project Description",
-  "base_docker_image": "manifoldai/orbyter-ml-dev:3.3",
+  "base_docker_image": "manifoldai/orbyter-ml-dev:3.5",
   "mlflow_uri": "/mnt/experiments",
   "mlflow_artifact": ""
 }

--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.package_name }}/scripts/train.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.package_name }}/scripts/train.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 )
 @setup_logging_env
 def _main(config_file):
-    """ Train CLI Entrypoint """
+    """Train CLI Entrypoint"""
     main(config_file=config_file)
 
 


### PR DESCRIPTION
# Context

This just changes the default orbyter docker image to `orbyter-ml-dev:3.5`.

# Changes
* Updated default image to 3.5
* Removed leading and trailing whitespace in docstring in `scripts/train.py` that caused the latest version of `black` to complain