### PR TITLE
updating the Makefile to fix the issue with the blank .env file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.x', '3.x']
+        python-version: ['3.x']
     name: Test by running cookiecutter with Python ${{ matrix.python-version }}
     env:
       TEST_PROJECT: foundation

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ By using containers early in the development cycle you can remove a lot of the c
 We are trying to bridge the gap that exists between data science and dev/operations teams today. We wrote about it here:
 https://medium.com/manifold-ai/torus-a-toolkit-for-docker-first-data-science-bddcb4c97b52
 
+## Support
+
+Orbyter cookiecutter supports Python 3.x
 
 # Project Set-up
 

--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -59,8 +59,8 @@ format: isort black ## Formats repo by running black and isort on all files
 lint: format ## Deprecated. Here to support old workflow
 
 
-.env: ## make an .env file
-	touch .env
+.env: ## copy the env_template if .env file does not exist
+	cp env_template .env
 
 dev-start: .env ## Primary make command for devs, spins up containers
 	docker-compose -f $(COMPOSE_FILE) --project-name $(PROJECT) up -d --no-recreate


### PR DESCRIPTION
# Context
Recreating the fix that we put in place in the newhire_onboard repo to fix the issue where the blank .env file prevents the mlflow container from working correctly

# Changes

* Updated the Makefile to copy the env_template to the .env file rather than creating a blank .env file if one does not already exist

