### PR TITLE
Remove 2.7 test. It fails a library depedency for cookiecutter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.x', '3.x']
+        python-version: ['3.x']
     name: Test by running cookiecutter with Python ${{ matrix.python-version }}
     env:
       TEST_PROJECT: foundation


### PR DESCRIPTION
We don't really need 2.7 for this repo